### PR TITLE
Better glob search.

### DIFF
--- a/lib/Sprockets/Locator.php
+++ b/lib/Sprockets/Locator.php
@@ -321,14 +321,14 @@ class Locator
 
 			foreach ($path['directories'] as $directory)
 			{
-				$files = glob(rtrim($directory, '/') . '/' . $prefix . substr($name . '.' . $ext, 0, -1) . '*');
+				$files = glob(rtrim($directory, '/') . '/' . $prefix . $name . '.*');
 
 				if ($files)
 				{
-					self::$files[$this->prefix][$ext][$name] = $files[0];
+					self::$files[$this->prefix][$ext][$name] = end($files);
 					self::$file_added = true;
 
-					return $files[0];
+					return self::$files[$this->prefix][$ext][$name];
 				}
 			}
 		}


### PR DESCRIPTION
When searching for the file a glob is used to capture all the files that
have the right prefix. There are a few problems with the existing setup.
- It currently chops off the last character. I don't see any reason for this
  and am guessing it is from some sort of refactor. Basically if your file
  is application.css it does glob on application.cs*. Of course if your file
  is named application.css.scss it still matches. But it doesn't really
  serve any purpose.
- It includes the extension in it's search which I am not certain is desired.
  If we are using some 3rd party library (say the sass library Bourbon) the
  files don't have the pipeline naming convention inherited from Rails. So
  the file will be called foo.scss instead of foo.css.scss. By including the
  extension we remove the ability to use these library files directly and are
  forced to rename the files to use the asset pipeline. To fix this I have
  changed the glob to be "foo._" instead of "foo.css_"
- The extension did serve a useful purpose of zeroing on on the right file.
  If you have a file jquery.js and jquery.some-ext.js and includes 'jquery'
  then the previous glob of jquery.js\* had the right file but the new glob
  matches both files even though it should just match the first file. Since
  glob is sorted grabbing the first item from the array results in us processing
  the wrong file. Luckily this is easily fixed by just grabbing the last item
  in the array instead of the first item.
