### PR TITLE
Overwrite the file list dependencies

### DIFF
--- a/lib/Sprockets/Cache.php
+++ b/lib/Sprockets/Cache.php
@@ -14,14 +14,13 @@ class Cache
 			'cache_directory' => $pipeline->getOption('CACHE_DIRECTORY'),
 			'minify' => false,
 			'manifest' => null,
-			'force' => false
 		), $options);
 	}
 	
 	private function getDependenciesFilename()
 	{
 		return $this->options['cache_directory'] . 'dependencies_' .
-		 $this->pipeline->getPrefix() . '.' . $this->type . '.txt';
+		 $this->pipeline->getPrefix() . $this->pipeline->getManifestName() . '.' . $this->type . '.txt';
 	}
     
 	private function getFilename()
@@ -36,7 +35,6 @@ class Cache
 	private function isFresh()
 	{
 		$cache_directory = $this->options['cache_directory'];
-		$overwrite = (bool) $this->options['force']; 
 	
 		if (!file_exists($cache_directory))
 			mkdir($cache_directory);
@@ -44,7 +42,7 @@ class Cache
 			throw new \InvalidArgumentException(sprintf('Cache directory "%s" is not a valid directory', $cache_directory));
 	
 		$path = $this->getDependenciesFilename();
-		if (!file_exists($path) || $overwrite)
+		if (!file_exists($path))
 			return false;
 		
 		$dependencies_file = file_get_contents($path);

--- a/lib/Sprockets/Cache.php
+++ b/lib/Sprockets/Cache.php
@@ -14,6 +14,7 @@ class Cache
 			'cache_directory' => $pipeline->getOption('CACHE_DIRECTORY'),
 			'minify' => false,
 			'manifest' => null,
+			'force' => false
 		), $options);
 	}
 	
@@ -35,6 +36,7 @@ class Cache
 	private function isFresh()
 	{
 		$cache_directory = $this->options['cache_directory'];
+		$overwrite = (bool) $this->options['force']; 
 	
 		if (!file_exists($cache_directory))
 			mkdir($cache_directory);
@@ -42,7 +44,7 @@ class Cache
 			throw new \InvalidArgumentException(sprintf('Cache directory "%s" is not a valid directory', $cache_directory));
 	
 		$path = $this->getDependenciesFilename();
-		if (!file_exists($path))
+		if (!file_exists($path) || $overwrite)
 			return false;
 		
 		$dependencies_file = file_get_contents($path);

--- a/lib/Sprockets/Pipeline.php
+++ b/lib/Sprockets/Pipeline.php
@@ -12,7 +12,7 @@ class Pipeline
 
 	private $extensions,
 		$dependencies,
-		$manifest_name = 'application',
+		$manifest_name = NULL,
 		$prefix,
 		$registered_files = array(),
 		$options = array();
@@ -55,6 +55,8 @@ class Pipeline
 		
 		if ($manifest) //this if is why $this->manifest_name is used for File::__construct() below
 			$this->manifest_name = $manifest;
+		else
+			$this->manifest_name = 'application';
 
 		$this->registered_files[$type] = array();
 
@@ -146,6 +148,11 @@ class Pipeline
 	public function getMainFile($type)
 	{
 		return $this->locator->getFile($this->manifest_name, $type);
+	}
+
+	public function getManifestName()
+	{
+		return $this->manifest_name;
 	}
 
 	/**

--- a/lib/Sprockets/Pipeline.php
+++ b/lib/Sprockets/Pipeline.php
@@ -12,7 +12,7 @@ class Pipeline
 
 	private $extensions,
 		$dependencies,
-		$manifest_name = NULL,
+		$manifest_name = 'application',
 		$prefix,
 		$registered_files = array(),
 		$options = array();
@@ -55,8 +55,6 @@ class Pipeline
 		
 		if ($manifest) //this if is why $this->manifest_name is used for File::__construct() below
 			$this->manifest_name = $manifest;
-		else
-			$this->manifest_name = 'application';
 
 		$this->registered_files[$type] = array();
 


### PR DESCRIPTION
I have a problem:

Having two controller methods calling different javascript and stylesheet files, if i want to change the manifest from A to B (as an option argument) in `Cache` class, the `isFresh()` method couldn't detect the dependency changes.

Maybe we could force it passing an option argument called `force`.

    $cache = new Sprockets\Cache($pipeline, 'css', $vars = array(), $options = array(
        'force' => TRUE
    ));