### PR TITLE
Add more font file extensions, and fix CSS filter url path

### DIFF
--- a/lib/Sprockets/Filter/Css.php
+++ b/lib/Sprockets/Filter/Css.php
@@ -19,8 +19,9 @@ class Css extends Base
 				return 'url(' . $match[1] . ')';
 
 			$file = new File(($dir ? $dir . '/' : '') . $match[1]);
+
 			//XXX maybe we should actually cache the image?
-			return 'url(' . $base_url . $file->getFilepath() . ')';
+			return 'url(' . preg_replace('/(?<!:)\/\//', '/' ,$base_url . $file->getFilepath()) . ')';
 		}, $content);
 	}
 }

--- a/lib/Sprockets/Locator.php
+++ b/lib/Sprockets/Locator.php
@@ -83,11 +83,13 @@ class Locator
 			case 'jpg':
 			case 'jpeg':
 				return 'img';
-
-			case 'otf':
 			case 'eot':
-			case 'woff':
+			case 'otf':
 			case 'ttf':
+			case 'svc':
+			case 'svg':
+			case 'woff':
+			case 'woff2':
 				return 'font';
 		}
 		return $ext;
@@ -105,7 +107,7 @@ class Locator
 	{
 		static $extensions = array('js', 'html', 'css', 'txt',
 			'png', 'gif', 'jpg', 'jpeg',
-			'otf', 'eot', 'woff', 'ttf');
+			'eot', 'svc', 'woff', 'woff2','otf', 'ttf','svg');
 
 		$filename_parts = explode('.', $name);
 		$name_parts = array();

--- a/test/index.php
+++ b/test/index.php
@@ -9,6 +9,9 @@ require __DIR__.'/../vendor/autoload.php';
 $paths = str_replace('%template%', 'MyTemplate', file_get_contents(__DIR__.'/paths.json'));
 $paths = json_decode($paths, true);
 
+# Change one test path to absolute:
+$paths['template']['directories'][0] = __DIR__.'/'.$paths['template']['directories'][0];
+
 class MeowFilter extends Sprockets\Filter\Base
 {
 	public function __invoke($content, $file, $dir, $vars)


### PR DESCRIPTION
Hello again my friend @vendethiel!

I realize that there are missing some *Font* extensions, so i added for you. 

Also, replace all occurrences of "//" as long as they are not preceded by ":"  in `Sprockets\Filter\CSS` class.
