### PR TITLE
Cache Directory (assets)

### DIFF
--- a/lib/Sprockets/Cache.php
+++ b/lib/Sprockets/Cache.php
@@ -11,7 +11,7 @@ class Cache
 		$this->type = $type;
 		$this->vars = $vars;
 		$this->options = array_merge(array(
-			'cache_directory' => $pipeline->getOption('CACHE_DIRECTORY'),
+			'cache_directory' => $pipeline->getCacheDirectory(),
 			'minify' => false,
 			'manifest' => null,
 		), $options);


### PR DESCRIPTION
In `Pipeline` class on `getCacheDirectory` method, the CACHE_DIRECTORY changes from:

    $this->getOption('CACHE_DIRECTORY')

to: 

    $this->getOption('CACHE_DIRECTORY').'assets/'

When the `Sprockets\Cache` class gets the CACHE_DIRECTORY from the `Pipeline` class it gets incomplete, so i change it with the method `getCacheDirectory()`, i think this is the expected output in first instance.